### PR TITLE
Fix wrongly escaped regular expressions.

### DIFF
--- a/classes/pluginbase/dataformfieldrenderer.php
+++ b/classes/pluginbase/dataformfieldrenderer.php
@@ -259,10 +259,10 @@ abstract class dataformfieldrenderer {
         $field = $this->_field;
         $patterns = array_keys($definitions);
 
+        foreach($patterns as &$pattern) {
+            $pattern = preg_quote($pattern, '/');
+        }
         $delims = implode('|', $patterns);
-
-        // Escape [ and ] and the pattern rule character *.
-        $delims = quotemeta($delims);
 
         $parts = preg_split("/($delims)/", $field->label, null, PREG_SPLIT_DELIM_CAPTURE);
         $htmlparts = '';

--- a/classes/pluginbase/dataformview.php
+++ b/classes/pluginbase/dataformview.php
@@ -1071,9 +1071,11 @@ class dataformview {
      * @param array $patterns array of arrays of pattern replacement pairs
      */
     protected function split_tags($patterns, $subject) {
+        foreach($patterns as &$pattern) {
+            $pattern = preg_quote($pattern, '/');
+        }
+
         $delims = implode('|', $patterns);
-        // Escape [ and ] and the pattern rule character *.
-        $delims = quotemeta($delims);
 
         $elements = preg_split("/($delims)/", $subject, null, PREG_SPLIT_DELIM_CAPTURE);
 
@@ -1219,7 +1221,7 @@ class dataformview {
         $pluginfileurl = isset($options['pluginfileurl']) ? $options['pluginfileurl'] : null;
         if ($pluginfileurl) {
             $pluginfilepath = \moodle_url::make_file_url("/pluginfile.php", "/{$this->df->context->id}/mod_dataform/content");
-            $pattern = str_replace('/', '\/', $pluginfilepath);
+            $pattern = preg_quote($pluginfilepath, '/');
             $pattern = "/$pattern\/\d+\//";
             $html = preg_replace($pattern, $pluginfileurl, $html);
         }


### PR DESCRIPTION
Most regular expressions in the project are wrongly escaped. I fixed the ones that had the same error, but there are others. All preg_* functions that receive a variable as pattern parameter should be checked.

Without this fix there was a parsing error, to test set the name of a field something like: "A / B"