### PR TITLE
subplugins.json

### DIFF
--- a/db/subplugins.json
+++ b/db/subplugins.json
@@ -1,0 +1,7 @@
+{
+    "plugintypes": {
+		"dataformfield": "mod\/dataform\/field",
+		"dataformview": "mod\/dataform\/view",
+		"dataformtool": "mod\/dataform\/tool"
+    }
+}

--- a/db/subplugins.php
+++ b/db/subplugins.php
@@ -19,8 +19,4 @@
  * @copyright 2012 Itamar Tzadok
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-$subplugins = array(
-    'dataformfield'  => 'mod/dataform/field',
-    'dataformview' => 'mod/dataform/view',
-    'dataformtool' => 'mod/dataform/tool',
-);
+$subplugins = (array) json_decode(file_get_contents(__DIR__ . "/subplugins.json"))->plugintypes;


### PR DESCRIPTION
fixed: Use of subplugins.php has been deprecated. Please update your 'moodle/mod/dataform' plugin to provide a subplugins.json file instead.

for moodle 3.8 and higher
https://docs.moodle.org/dev/Subplugins